### PR TITLE
[Fix]  Sync Skill Anim & LoserBuff & SyncHpRatio & Levelup

### DIFF
--- a/HIGHFIVE/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/HIGHFIVE/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -53,6 +53,8 @@ MonoBehaviour:
   - SyncTime
   - SynPage
   - SyncRound
+  - SyncActive
+  - SyncParameter
   DisableAutoOpenWizard: 1
   ShowSettings: 1
   DevRegionSetOnce: 1

--- a/HIGHFIVE/Assets/Resources/Animations/SkillEffectController/BerserkEffectController.controller
+++ b/HIGHFIVE/Assets/Resources/Animations/SkillEffectController/BerserkEffectController.controller
@@ -29,7 +29,7 @@ AnimatorState:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: test
+  m_Name: BerserkAnim
   m_Speed: 1
   m_CycleOffset: 0
   m_Transitions: []
@@ -59,7 +59,7 @@ AnimatorStateMachine:
   m_ChildStates:
   - serializedVersion: 1
     m_State: {fileID: 1926215385739158731}
-    m_Position: {x: 340, y: 50, z: 0}
+    m_Position: {x: 310, y: 200, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []

--- a/HIGHFIVE/Assets/Resources/Prefabs/Character/Warrior.prefab
+++ b/HIGHFIVE/Assets/Resources/Prefabs/Character/Warrior.prefab
@@ -1730,6 +1730,7 @@ MonoBehaviour:
   ObservedComponents:
   - {fileID: 1272446769521281065}
   - {fileID: 4267410153626354203}
+  - {fileID: 2516158035854156627}
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
@@ -3425,6 +3426,7 @@ GameObject:
   - component: {fileID: 3832634007281768541}
   - component: {fileID: 5469947983455146908}
   - component: {fileID: 734269980295825859}
+  - component: {fileID: 2516158035854156627}
   m_Layer: 0
   m_Name: BerserkEffect
   m_TagString: Untagged
@@ -3525,3 +3527,24 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
+--- !u!114 &2516158035854156627
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9169128672285603980}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b8c4a61274f60b4ea5fb4299cfdbf14, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ShowLayerWeightsInspector: 1
+  ShowParameterInspector: 1
+  m_SynchronizeParameters:
+  - Type: 4
+    SynchronizeType: 0
+    Name: isBerserk
+  m_SynchronizeLayers:
+  - SynchronizeType: 0
+    LayerIndex: 0

--- a/HIGHFIVE/Assets/Resources/Prefabs/SkillEffect/FireBallEffect.prefab
+++ b/HIGHFIVE/Assets/Resources/Prefabs/SkillEffect/FireBallEffect.prefab
@@ -175,6 +175,7 @@ GameObject:
   - component: {fileID: 6212209806844308343}
   - component: {fileID: 7474229517834717147}
   - component: {fileID: 3113868316179452967}
+  - component: {fileID: 8332455345592614234}
   m_Layer: 0
   m_Name: FireBall
   m_TagString: Untagged
@@ -282,3 +283,24 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b75d5bc768892be4ea373a3bb67a5c6e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &8332455345592614234
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5615301016237257257}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b8c4a61274f60b4ea5fb4299cfdbf14, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ShowLayerWeightsInspector: 1
+  ShowParameterInspector: 1
+  m_SynchronizeParameters:
+  - Type: 4
+    SynchronizeType: 0
+    Name: isTrigger
+  m_SynchronizeLayers:
+  - SynchronizeType: 0
+    LayerIndex: 0

--- a/HIGHFIVE/Assets/Scripts/Content/Buff/StabbingBuff.cs
+++ b/HIGHFIVE/Assets/Scripts/Content/Buff/StabbingBuff.cs
@@ -1,3 +1,4 @@
+using Photon.Pun;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -24,9 +25,13 @@ public class StabbingBuff : BaseBuff
     }
     public override IEnumerator ApplyEffect(GameObject target, GameObject shooter = null)
     {
+        myCharacter.transform.Find("BerserkEffect").gameObject.SetActive(true);
+        myCharacter.GetComponent<PhotonView>().RPC("SyncActive", RpcTarget.All, true);
         yield return new WaitForSeconds(buffData.effectTime);
         target.GetComponent<Stat>().MoveSpeed -= _stabbingBuffData.spd;
         yield return new WaitForSeconds(buffData.duration - buffData.effectTime);
+        myCharacter.transform.Find("BerserkEffect").gameObject.SetActive(false);
+        myCharacter.GetComponent<PhotonView>().RPC("SyncActive", RpcTarget.All, false);
         myCharacter.SkillController.CallSkillExecute(myCharacter.CharacterSkill.FirstSkill);
     }
 

--- a/HIGHFIVE/Assets/Scripts/Content/Skill/Warrior/Stabbing.cs
+++ b/HIGHFIVE/Assets/Scripts/Content/Skill/Warrior/Stabbing.cs
@@ -38,7 +38,6 @@ public class Stabbing : BaseSkill
         skillData.coolTimeicon.fillAmount = 1;
         BaseBuff stabbingBuff = new StabbingBuff();
         myCharacter.BuffController.AddBuff(stabbingBuff);
-
         myCharacter.Animator.SetBool(myCharacter.PlayerAnimationData.SkillDelayTimeHash, true);
         myCharacter.SkillController.CallSkillDelay(myCharacter.CharacterSkill.FirstSkill.skillData);
     }

--- a/HIGHFIVE/Assets/Scripts/Content/Stat/Character/CharacterStat.cs
+++ b/HIGHFIVE/Assets/Scripts/Content/Stat/Character/CharacterStat.cs
@@ -1,3 +1,4 @@
+using Photon.Pun;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -52,6 +53,8 @@ public class CharacterStat : Stat
             myStat.AttackSpeed += 0.1f;
             myStat.MaxHp += 40;
             myStat.CurHp += 40;
+            myStat.gameObject.GetComponent<PhotonView>().RPC("SetHpRPC", RpcTarget.All, myStat.CurHp);
+            
 
             if (myStat.Exp > myStat.MaxExp)
             {

--- a/HIGHFIVE/Assets/Scripts/Object/Character/Character.cs
+++ b/HIGHFIVE/Assets/Scripts/Object/Character/Character.cs
@@ -182,4 +182,9 @@ public class Character : Creature
             
         }
     }
+    [PunRPC]
+    public void SyncActive(bool isActive)
+    {
+        gameObject.transform.Find("BerserkEffect")?.gameObject.SetActive(isActive);
+    }
 }

--- a/HIGHFIVE/Assets/Scripts/Object/Projectile/FireBallProjectile.cs
+++ b/HIGHFIVE/Assets/Scripts/Object/Projectile/FireBallProjectile.cs
@@ -47,8 +47,8 @@ public class FireBallProjectile : MonoBehaviour
                 CapsuleCollider2D collider = gameObject.GetComponent<CapsuleCollider2D>();
                 Destroy(collider);
                 _animator.SetBool("isTrigger", true);
+                GetComponent<PhotonView>().RPC("SyncParameter", RpcTarget.All, true);
                 gameObject.GetComponent<Rigidbody2D>().velocity = Vector2.zero * 0;
-                
             }
         }
     }
@@ -58,4 +58,9 @@ public class FireBallProjectile : MonoBehaviour
         _shooter = shooter;
     }
 
+    [PunRPC]
+    private void SyncParameter(bool isTrigger)
+    {
+        _animator.SetBool("isTrigger", isTrigger);
+    }
 }

--- a/HIGHFIVE/Assets/Scripts/UI/GameScene_UI/RoundTimer.cs
+++ b/HIGHFIVE/Assets/Scripts/UI/GameScene_UI/RoundTimer.cs
@@ -96,7 +96,7 @@ public class RoundTimer : MonoBehaviour
         if (pageNum == (int)Define.Page.Farming)
         {
             Main.GameManager.page = Define.Page.Farming;
-            if (roundLogic.currentRound  != 1)
+            if (roundLogic.currentRound  > 1)
             {
                 _gameFieldController.CallFarmingEvent();
             }

--- a/HIGHFIVE/Assets/Scripts/UI/World_UI/HealthBar.cs
+++ b/HIGHFIVE/Assets/Scripts/UI/World_UI/HealthBar.cs
@@ -52,6 +52,7 @@ public class HealthBar : UIBase
     private void SetHpRatio(int curHp, int maxHp)
     {
         float ratio = curHp / (float)maxHp;
+        if (ratio <= 0) return;
         transform.parent.GetComponent<PhotonView>().RPC("SyncHpRatio", RpcTarget.All, ratio);
     }
 }


### PR DESCRIPTION
스킬 애니메이션 동기화
게임 시작시 패자의 분노가 생기는 버그
SyncHpRatio가 몬스터가 파괴되었을때는 동작안하게 수정
레벨없 시에 현재 Hp를 동기화